### PR TITLE
Added fix for the checkov errors in the deployment.yaml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ node_modules
 cdk.out
 
 .env
+
+.idea

--- a/assets/argocd/deployment.yaml
+++ b/assets/argocd/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx
+  namespace: nginx
   labels:
     app.kubernetes.io/name: nginx
 spec:
@@ -14,9 +15,14 @@ spec:
       labels:
         app.kubernetes.io/name: nginx
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      automountServiceAccountToken: false
       containers:
         - name: nginx
-          image: nginx:latest
+          image: nginx@sha256:f9c14fe76c502f4d49d0f0d5842b813d8bd7fd7b12c005eb31c4b9f8ae67f825  # Changed to use digest
+          imagePullPolicy: Always  # Added imagePullPolicy
           resources:
             limits:
               cpu: "0.5"
@@ -26,6 +32,26 @@ spec:
               memory: "500Mi"
           ports:
             - containerPort: 80
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 10001  # Changed to a higher UID
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 10
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The following errors were resolved:

CKV_K8S_37: "Minimize the admission of containers with capabilities assigned"
CKV_K8S_31: "Ensure that the seccomp profile is set to docker/default or runtime/default"
CKV_K8S_8: "Liveness Probe Should be Configured"
CKV_K8S_20: "Containers should not run with allowPrivilegeEscalation"
CKV_K8S_40: "Containers should run as a high UID to avoid host conflict"
CKV_K8S_22: "Use read-only filesystem for containers where possible"
CKV_K8S_9: "Readiness Probe Should be Configured"
CKV_K8S_28: "Minimize the admission of containers with the NET_RAW capability"
CKV_K8S_29: "Apply security context to your pods and containers"
CKV_K8S_30: "Apply security context to your containers"
CKV_K8S_14: "Image Tag should be fixed - not latest or blank"
CKV_K8S_38: "Ensure that Service Account Tokens are only mounted where necessary"
CKV_K8S_21: "The default namespace should not be used"
CKV_K8S_23: "Minimize the admission of root containers"
CKV_K8S_43: "Image should use digest"

Closes #6 